### PR TITLE
SSR을 이용한 SNS 로그인 구현(Google, Github, Kakao, Naver)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "next": "13.1.6",
+        "next-auth": "^4.20.1",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "typescript": "4.9.5"
@@ -18,6 +19,7 @@
         "@tailwindcss/forms": "^0.5.3",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
+        "@types/next-auth": "^3.15.0",
         "@types/node": "^18.13.0",
         "@types/react": "^18.0.28",
         "@types/react-dom": "^18.0.10",
@@ -600,7 +602,6 @@
       "version": "7.20.13",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.13.tgz",
       "integrity": "sha512-gt3PKXs0DBoL9xCvOIIZ2NEqAGZqHjAnmVbfQtB620V0uReIQutpel14KcneZuer7UioY8ALKZ7iocavvzTNFA==",
-      "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.13.11"
       },
@@ -1549,6 +1550,14 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@panva/hkdf": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.0.4.tgz",
+      "integrity": "sha512-003xWiCuvePbLaPHT+CRuaV4GlyCAVm6XYSbBZDHoWZGn1mNkVKFaDbGJjjxmEFvizUwlCoM6O18FCBMMky2zQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/@pkgr/utils": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@pkgr/utils/-/utils-2.3.1.tgz",
@@ -1879,6 +1888,16 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
+    },
+    "node_modules/@types/next-auth": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@types/next-auth/-/next-auth-3.15.0.tgz",
+      "integrity": "sha512-ZVfejlu81YiIRX1m0iKAfvZ3nK7K9EyZWhNARNKsFop8kNAgEvMnlKpTpwN59xkK2OhyWLagPuiDAVBYSO9jSA==",
+      "deprecated": "This is a stub types definition. next-auth provides its own type definitions, so you do not need this installed.",
+      "dev": true,
+      "dependencies": {
+        "next-auth": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "18.13.0",
@@ -2933,6 +2952,14 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
+    },
+    "node_modules/cookie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/create-require": {
       "version": "1.1.1",
@@ -6353,6 +6380,14 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/jose": {
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.13.1.tgz",
+      "integrity": "sha512-MSJQC5vXco5Br38mzaQKiq9mwt7lwj2eXpgpRyQYNHYt2lq1PjkWa7DLXX0WVcQLE9HhMh3jPiufS7fhJf+CLQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-sdsl": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.3.0.tgz",
@@ -6846,6 +6881,33 @@
         }
       }
     },
+    "node_modules/next-auth": {
+      "version": "4.20.1",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.20.1.tgz",
+      "integrity": "sha512-ZcTUN4qzzZ/zJYgOW0hMXccpheWtAol8QOMdMts+LYRcsPGsqf2hEityyaKyECQVw1cWInb9dF3wYwI5GZdEmQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@panva/hkdf": "^1.0.2",
+        "cookie": "^0.5.0",
+        "jose": "^4.11.4",
+        "oauth": "^0.9.15",
+        "openid-client": "^5.4.0",
+        "preact": "^10.6.3",
+        "preact-render-to-string": "^5.1.19",
+        "uuid": "^8.3.2"
+      },
+      "peerDependencies": {
+        "next": "^12.2.5 || ^13",
+        "nodemailer": "^6.6.5",
+        "react": "^17.0.2 || ^18",
+        "react-dom": "^17.0.2 || ^18"
+      },
+      "peerDependenciesMeta": {
+        "nodemailer": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/next-router-mock": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/next-router-mock/-/next-router-mock-0.9.1.tgz",
@@ -6926,6 +6988,11 @@
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.2.tgz",
       "integrity": "sha512-90yv+6538zuvUMnN+zCr8LuV6bPFdq50304114vJYJ8RDyK8D5O9Phpbd6SZWgI7PwzmmfN1upeOJlvybDSgCw==",
       "dev": true
+    },
+    "node_modules/oauth": {
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
+      "integrity": "sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA=="
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -7064,6 +7131,14 @@
       "integrity": "sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw==",
       "dev": true
     },
+    "node_modules/oidc-token-hash": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.0.1.tgz",
+      "integrity": "sha512-EvoOtz6FIEBzE+9q253HsLCVRiK/0doEJ2HCvvqMQb3dHZrP3WlJKYtJ55CRTw4jmYomzH4wkPuCj/I3ZvpKxQ==",
+      "engines": {
+        "node": "^10.13.0 || >=12.0.0"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -7104,6 +7179,44 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/openid-client": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.4.0.tgz",
+      "integrity": "sha512-hgJa2aQKcM2hn3eyVtN12tEA45ECjTJPXCgUh5YzTzy9qwapCvmDTVPWOcWVL0d34zeQoQ/hbG9lJhl3AYxJlQ==",
+      "dependencies": {
+        "jose": "^4.10.0",
+        "lru-cache": "^6.0.0",
+        "object-hash": "^2.0.1",
+        "oidc-token-hash": "^5.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/openid-client/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/openid-client/node_modules/object-hash": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/openid-client/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/optionator": {
       "version": "0.9.1",
@@ -7471,6 +7584,31 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
     },
+    "node_modules/preact": {
+      "version": "10.13.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.13.1.tgz",
+      "integrity": "sha512-KyoXVDU5OqTpG9LXlB3+y639JAGzl8JSBXLn1J9HTSB3gbKcuInga7bZnXLlxmK94ntTs1EFeZp0lrja2AuBYQ==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/preact-render-to-string": {
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-5.2.6.tgz",
+      "integrity": "sha512-JyhErpYOvBV1hEPwIxc/fHWXPfnEGdRKxc8gFdAZ7XV4tlzyzG847XAyEZqoDnynP88akM4eaHcSOzNcLWFguw==",
+      "dependencies": {
+        "pretty-format": "^3.8.0"
+      },
+      "peerDependencies": {
+        "preact": ">=10"
+      }
+    },
+    "node_modules/preact-render-to-string/node_modules/pretty-format": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
+      "integrity": "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew=="
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -7805,8 +7943,7 @@
     "node_modules/regenerator-runtime": {
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-      "dev": true
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.4.3",
@@ -8748,6 +8885,14 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "next": "13.1.6",
+    "next-auth": "^4.20.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "typescript": "4.9.5"
@@ -23,6 +24,7 @@
     "@tailwindcss/forms": "^0.5.3",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
+    "@types/next-auth": "^3.15.0",
     "@types/node": "^18.13.0",
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.0.10",

--- a/src/components/layout/ContentHeader.tsx
+++ b/src/components/layout/ContentHeader.tsx
@@ -1,13 +1,24 @@
+import { signOut } from 'next-auth/react';
 import * as React from 'react';
 import { AiOutlineStar } from 'react-icons/ai';
 import { BiMessageDetail, BiTime } from 'react-icons/bi';
 import { FiMoreHorizontal } from 'react-icons/fi';
 
 export default function Header() {
+  const handleLogout = () => {
+    signOut();
+  };
+
   return (
     <header>
       <div className="flex flex-col flex-wrap items-center p-5 md:flex-row">
         <nav className="flex flex-wrap items-center justify-center text-base md:ml-auto">
+          <span
+            className="mr-3 cursor-pointer rounded-md py-1 px-2 hover:bg-gray-200 "
+            onClick={handleLogout}
+          >
+            로그아웃
+          </span>
           <span className="mr-3 cursor-pointer rounded-md py-1 px-2 hover:bg-gray-200 ">
             공유
           </span>

--- a/src/components/layout/Sidebar/MyPage.tsx
+++ b/src/components/layout/Sidebar/MyPage.tsx
@@ -1,12 +1,12 @@
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import React from 'react';
+import React, { useState } from 'react';
 import { AiFillDelete, AiOutlineRight } from 'react-icons/ai';
 import { useRecoilValue } from 'recoil';
 
 import { queryClient } from '@/lib/api/queryClient';
 import usePageMutation from '@/lib/hooks/usePageMutation';
-import { pageList } from '@/lib/recoil';
+import { pageListState } from '@/lib/recoil';
 import { changeParam } from '@/lib/service';
 
 import { PageType } from '@/types';
@@ -14,9 +14,10 @@ import { queryKeys } from '@/types/commonType';
 
 function MyPage() {
   const router = useRouter();
-  const pages = useRecoilValue(pageList);
+  const pages = useRecoilValue(pageListState);
   const { removePage } = usePageMutation();
   const { mutate: deletePageMutate } = removePage;
+  const [selectedId, setSelected] = useState<string | undefined>('');
 
   const handleDelete = (id?: string) => {
     deletePageMutate(id ?? '', {
@@ -30,6 +31,9 @@ function MyPage() {
     });
   };
 
+  const getSelectedClass = (id?: string) =>
+    selectedId === id ? 'selectedList' : '';
+
   return (
     <>
       <div className="ml-4 mb-2 text-sm text-gray-500">개인 페이지</div>
@@ -39,22 +43,28 @@ function MyPage() {
             return (
               <div
                 key={page._id}
-                className="flex justify-between py-1 pl-4 hover:bg-gray-200"
+                className={`flex justify-between py-1 pl-4 hover:bg-gray-200 ${getSelectedClass(
+                  page?._id,
+                )}`}
               >
-                <Link href={`/page/${changeParam(page.title)}${page._id}`}>
+                <Link
+                  href={`/page/${changeParam(page.title)}${page._id}`}
+                  className="selected flex w-full justify-between"
+                  onClick={() => setSelected(page?._id)}
+                >
                   <div className="flex items-center">
                     <span>
                       <AiOutlineRight className="text-sm  text-gray-600" />
                     </span>
                     <li className="ml-2 text-gray-600">{page?.title}</li>
                   </div>
+                  <div className="flex items-center">
+                    <AiFillDelete
+                      className="mr-4 flex cursor-pointer items-center text-gray-600 hover:text-red-500"
+                      onClick={() => handleDelete(page._id)}
+                    />
+                  </div>
                 </Link>
-                <div className="flex items-center">
-                  <AiFillDelete
-                    className="mr-4 flex cursor-pointer items-center text-gray-600 hover:text-red-500"
-                    onClick={() => handleDelete(page._id)}
-                  />
-                </div>
               </div>
             );
           })}

--- a/src/components/layout/Sidebar/MyPage.tsx
+++ b/src/components/layout/Sidebar/MyPage.tsx
@@ -1,34 +1,27 @@
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import React, { useEffect } from 'react';
+import React from 'react';
 import { AiFillDelete, AiOutlineRight } from 'react-icons/ai';
-import { useQuery } from 'react-query';
-import { useSetRecoilState } from 'recoil';
+import { useRecoilValue } from 'recoil';
 
-import { getPageList } from '@/lib/api/page';
 import { queryClient } from '@/lib/api/queryClient';
 import usePageMutation from '@/lib/hooks/usePageMutation';
 import { pageList } from '@/lib/recoil';
 import { changeParam } from '@/lib/service';
 
 import { PageType } from '@/types';
+import { queryKeys } from '@/types/commonType';
 
 function MyPage() {
-  const { data } = useQuery('pages', getPageList);
-  const setPageList = useSetRecoilState(pageList);
+  const router = useRouter();
+  const pages = useRecoilValue(pageList);
   const { removePage } = usePageMutation();
   const { mutate: deletePageMutate } = removePage;
-  const router = useRouter();
-
-  useEffect(() => {
-    setPageList(data);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   const handleDelete = (id?: string) => {
     deletePageMutate(id ?? '', {
       onSuccess: () => {
-        queryClient.invalidateQueries('pages');
+        queryClient.invalidateQueries(queryKeys.pages);
         router.push('/');
       },
       onError: (error) => {
@@ -41,8 +34,8 @@ function MyPage() {
     <>
       <div className="ml-4 mb-2 text-sm text-gray-500">개인 페이지</div>
       <ul>
-        {data?.length > 0 &&
-          data.map((page: PageType) => {
+        {pages?.length > 0 &&
+          pages.map((page: PageType) => {
             return (
               <div
                 key={page._id}

--- a/src/lib/api/page.ts
+++ b/src/lib/api/page.ts
@@ -2,9 +2,11 @@ import axios from 'axios';
 
 import { PageType } from '@/types';
 
-export const getPageList = async () => {
+export const getPageList = async (email: string) => {
   try {
-    const { data } = await axios.get(process.env.LOCAL_BASE_URL + 'myPage');
+    const { data } = await axios.get(process.env.LOCAL_BASE_URL + 'myPage', {
+      params: { email },
+    });
 
     return data.pages;
   } catch (err) {

--- a/src/lib/api/queryClient.ts
+++ b/src/lib/api/queryClient.ts
@@ -5,7 +5,7 @@ export const queryClient = new QueryClient({
     queries: {
       retry: 0,
       staleTime: 60000,
-      suspense: true,
+      // suspense: true,
     },
   },
   queryCache: new QueryCache({

--- a/src/lib/api/queryClient.ts
+++ b/src/lib/api/queryClient.ts
@@ -5,7 +5,9 @@ export const queryClient = new QueryClient({
     queries: {
       retry: 0,
       staleTime: 60000,
-      // suspense: true,
+      refetchOnMount: false,
+      refetchOnReconnect: false,
+      refetchOnWindowFocus: false,
     },
   },
   queryCache: new QueryCache({
@@ -15,8 +17,5 @@ export const queryClient = new QueryClient({
         console.log('Error: ', error);
       }
     },
-    // onSuccess: (data) => {
-    //   console.log(data);
-    // },
   }),
 });

--- a/src/lib/api/user.ts
+++ b/src/lib/api/user.ts
@@ -1,0 +1,21 @@
+import axios from 'axios';
+
+import { UserType } from '@/types';
+
+export const createUser = async (body: UserType) => {
+  try {
+    const headers = {
+      'Content-Type': 'application/json',
+    };
+
+    const { data } = await axios.post<UserType>(
+      process.env.LOCAL_BASE_URL + 'user',
+      body,
+      { headers },
+    );
+
+    return data;
+  } catch (err) {
+    console.log(err);
+  }
+};

--- a/src/lib/hooks/useHomePage.ts
+++ b/src/lib/hooks/useHomePage.ts
@@ -4,14 +4,14 @@ import { useSetRecoilState } from 'recoil';
 
 import useUserMutation from './useUserMutation';
 import { getPageList } from '../api/page';
-import { pageList, userState } from '../recoil';
+import { pageListState, userState } from '../recoil';
 
 import { queryKeys } from '@/types/commonType';
 
 function useHomePage() {
   const { data: session } = useSession();
   const setUser = useSetRecoilState(userState);
-  const setPages = useSetRecoilState(pageList);
+  const setPages = useSetRecoilState(pageListState);
   const { addUser } = useUserMutation();
 
   const { mutate: addUserMutate } = addUser;

--- a/src/lib/hooks/useHomePage.ts
+++ b/src/lib/hooks/useHomePage.ts
@@ -1,0 +1,28 @@
+import { useSession } from 'next-auth/react';
+import { useQuery } from 'react-query';
+import { useSetRecoilState } from 'recoil';
+
+import useUserMutation from './useUserMutation';
+import { getPageList } from '../api/page';
+import { pageList, userState } from '../recoil';
+
+import { queryKeys } from '@/types/commonType';
+
+function useHomePage() {
+  const { data: session } = useSession();
+  const setUser = useSetRecoilState(userState);
+  const setPages = useSetRecoilState(pageList);
+  const { addUser } = useUserMutation();
+
+  const { mutate: addUserMutate } = addUser;
+  useQuery([...queryKeys.pages, session], async () => {
+    if (session) {
+      const data = await getPageList(session.user.email);
+      setUser(session.user);
+      addUserMutate(session.user);
+      setPages(data);
+    }
+  });
+}
+
+export default useHomePage;

--- a/src/lib/hooks/useUserMutation.ts
+++ b/src/lib/hooks/useUserMutation.ts
@@ -1,0 +1,11 @@
+import { useMutation } from 'react-query';
+
+import { createUser } from '@/lib/api/user';
+
+export default function useUserMutation() {
+  const addUser = useMutation(createUser);
+
+  return {
+    addUser,
+  };
+}

--- a/src/lib/recoil/index.ts
+++ b/src/lib/recoil/index.ts
@@ -1,7 +1,19 @@
 import { atom, RecoilEnv } from 'recoil';
 RecoilEnv.RECOIL_DUPLICATE_ATOM_KEY_CHECKING_ENABLED = false;
 
+import { AiFillGithub } from 'react-icons/ai';
+import { FcGoogle } from 'react-icons/fc';
+import { RiKakaoTalkFill } from 'react-icons/ri';
+import { SiNaver } from 'react-icons/si';
+
 import { PageType, UserType } from '@/types';
+
+export const LoginProperties = [
+  { icon: FcGoogle, style: '' },
+  { icon: AiFillGithub, style: 'bg-gray-800 text-white' },
+  { icon: RiKakaoTalkFill, style: 'bg-yellow-300' },
+  { icon: SiNaver, style: 'bg-green-500 text-white' },
+];
 
 export const pageState = atom<PageType>({
   key: 'page',

--- a/src/lib/recoil/index.ts
+++ b/src/lib/recoil/index.ts
@@ -1,4 +1,5 @@
-import { atom } from 'recoil';
+import { atom, RecoilEnv } from 'recoil';
+RecoilEnv.RECOIL_DUPLICATE_ATOM_KEY_CHECKING_ENABLED = false;
 
 import { PageType } from '@/types';
 

--- a/src/lib/recoil/index.ts
+++ b/src/lib/recoil/index.ts
@@ -1,7 +1,7 @@
 import { atom, RecoilEnv } from 'recoil';
 RecoilEnv.RECOIL_DUPLICATE_ATOM_KEY_CHECKING_ENABLED = false;
 
-import { PageType } from '@/types';
+import { PageType, UserType } from '@/types';
 
 export const pageState = atom<PageType>({
   key: 'page',
@@ -16,4 +16,13 @@ export const pageState = atom<PageType>({
 export const pageList = atom<PageType[]>({
   key: 'pageList',
   default: [],
+});
+
+export const userState = atom<UserType>({
+  key: 'user',
+  default: {
+    email: '',
+    image: '',
+    name: '',
+  },
 });

--- a/src/lib/recoil/index.ts
+++ b/src/lib/recoil/index.ts
@@ -11,12 +11,15 @@ import { PageType, UserType } from '@/types';
 export const LoginProperties = [
   { icon: FcGoogle, style: '' },
   { icon: AiFillGithub, style: 'bg-gray-800 text-white' },
-  { icon: RiKakaoTalkFill, style: 'bg-yellow-300' },
+  {
+    icon: RiKakaoTalkFill,
+    style: 'bg-yellow-300',
+  },
   { icon: SiNaver, style: 'bg-green-500 text-white' },
 ];
 
-export const pageState = atom<PageType>({
-  key: 'page',
+export const newPageState = atom<PageType>({
+  key: 'newPage',
   default: {
     _id: '',
     creator: '',
@@ -25,7 +28,7 @@ export const pageState = atom<PageType>({
   },
 });
 
-export const pageList = atom<PageType[]>({
+export const pageListState = atom<PageType[]>({
   key: 'pageList',
   default: [],
 });

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,4 +1,5 @@
 import { AppProps } from 'next/app';
+import { SessionProvider } from 'next-auth/react';
 import { Suspense } from 'react';
 import { QueryClientProvider } from 'react-query';
 import { RecoilRoot } from 'recoil';
@@ -12,7 +13,9 @@ function MyApp({ Component, pageProps }: AppProps) {
     <QueryClientProvider client={queryClient}>
       <RecoilRoot>
         <Suspense fallback={<div>Loading...</div>}>
-          <Component {...pageProps} />
+          <SessionProvider session={pageProps.session}>
+            <Component {...pageProps} />
+          </SessionProvider>
         </Suspense>
       </RecoilRoot>
     </QueryClientProvider>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -10,15 +10,15 @@ import { queryClient } from '@/lib/api/queryClient';
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (
-    <QueryClientProvider client={queryClient}>
-      <RecoilRoot>
-        <Suspense fallback={<div>Loading...</div>}>
-          <SessionProvider session={pageProps.session}>
+    <SessionProvider session={pageProps.session}>
+      <QueryClientProvider client={queryClient}>
+        <RecoilRoot>
+          <Suspense fallback={<div>Loading...</div>}>
             <Component {...pageProps} />
-          </SessionProvider>
-        </Suspense>
-      </RecoilRoot>
-    </QueryClientProvider>
+          </Suspense>
+        </RecoilRoot>
+      </QueryClientProvider>
+    </SessionProvider>
   );
 }
 

--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -1,0 +1,35 @@
+import NextAuth from 'next-auth';
+import GithubProvider from 'next-auth/providers/github';
+import GoogleProvider from 'next-auth/providers/google';
+import KakaoProvider from 'next-auth/providers/kakao';
+import NaverProvider from 'next-auth/providers/naver';
+
+export default NextAuth({
+  callbacks: {
+    session({ session }) {
+      return session;
+    },
+  },
+  session: {
+    strategy: 'jwt',
+  },
+  providers: [
+    GoogleProvider({
+      clientId: process.env.GOOGLE_CLIENT_ID as string,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET as string,
+    }),
+    GithubProvider({
+      clientId: process.env.GITHUB_CLIENT_ID as string,
+      clientSecret: process.env.GITHUB_CLIENT_SECRET as string,
+    }),
+    KakaoProvider({
+      clientId: process.env.KAKAO_CLIENT_ID as string,
+      clientSecret: process.env.KAKAO_CLIENT_SECRET as string,
+    }),
+    NaverProvider({
+      clientId: process.env.NAVER_CLIENT_ID as string,
+      clientSecret: process.env.NAVER_CLIENT_SECRET as string,
+    }),
+  ],
+  secret: process.env.JWT_SECRET as string,
+});

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,5 @@
 import { NextPageContext } from 'next';
-import { getProviders, getSession } from 'next-auth/react';
+import { getSession } from 'next-auth/react';
 import React from 'react';
 
 import useHomePage from '@/lib/hooks/useHomePage';
@@ -18,22 +18,27 @@ function HomePage() {
 }
 
 export async function getServerSideProps(context: NextPageContext) {
-  const { req, res } = context;
-  const session = await getSession({ req });
+  try {
+    const { req, res } = context;
+    const session = await getSession({ req });
 
-  if (!session && res) {
-    res.writeHead(302, {
-      Location: '/login',
-    });
-    res.end();
-    return;
+    if (!session && res) {
+      res.writeHead(302, {
+        Location: '/login',
+      });
+      res.end();
+      return { props: {} };
+    }
+
+    return { props: session };
+  } catch (error) {
+    return {
+      redirect: {
+        destination: '/login',
+        statusCode: 302,
+      },
+    };
   }
-
-  return {
-    props: {
-      providers: await getProviders(),
-    },
-  };
 }
 
 export default HomePage;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,34 +1,14 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { NextPageContext } from 'next';
-import { getProviders, getSession, useSession } from 'next-auth/react';
+import { getProviders, getSession } from 'next-auth/react';
 import React from 'react';
-import { useQuery } from 'react-query';
-import { useSetRecoilState } from 'recoil';
 
-import { getPageList } from '@/lib/api/page';
-import useUserMutation from '@/lib/hooks/useUserMutation';
-import { pageList, userState } from '@/lib/recoil';
+import useHomePage from '@/lib/hooks/useHomePage';
 
 import Content from '@/components/layout/Content';
 import Layout from '@/components/layout/Layout';
 
-import { queryKeys } from '@/types/commonType';
-
 function HomePage() {
-  const { data: session } = useSession();
-  const setUser = useSetRecoilState(userState);
-  const setPages = useSetRecoilState(pageList);
-  const { addUser } = useUserMutation();
-
-  const { mutate: addUserMutate } = addUser;
-  useQuery([...queryKeys.pages, session], async () => {
-    if (session) {
-      const data = await getPageList(session.user.email);
-      setUser(session.user);
-      addUserMutate(session.user);
-      setPages(data);
-    }
-  });
+  useHomePage();
 
   return (
     <Layout>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,12 +1,59 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { NextPageContext } from 'next';
+import { getProviders, getSession, useSession } from 'next-auth/react';
 import React from 'react';
+import { useQuery } from 'react-query';
+import { useSetRecoilState } from 'recoil';
+
+import { getPageList } from '@/lib/api/page';
+import useUserMutation from '@/lib/hooks/useUserMutation';
+import { pageList, userState } from '@/lib/recoil';
 
 import Content from '@/components/layout/Content';
 import Layout from '@/components/layout/Layout';
 
-export default function HomePage() {
+import { queryKeys } from '@/types/commonType';
+
+function HomePage() {
+  const { data: session } = useSession();
+  const setUser = useSetRecoilState(userState);
+  const setPages = useSetRecoilState(pageList);
+  const { addUser } = useUserMutation();
+
+  const { mutate: addUserMutate } = addUser;
+  useQuery([...queryKeys.pages, session], async () => {
+    if (session) {
+      const data = await getPageList(session.user.email);
+      setUser(session.user);
+      addUserMutate(session.user);
+      setPages(data);
+    }
+  });
+
   return (
     <Layout>
       <Content page={undefined} />
     </Layout>
   );
 }
+
+export async function getServerSideProps(context: NextPageContext) {
+  const { req, res } = context;
+  const session = await getSession({ req });
+
+  if (!session && res) {
+    res.writeHead(302, {
+      Location: '/login',
+    });
+    res.end();
+    return;
+  }
+
+  return {
+    props: {
+      providers: await getProviders(),
+    },
+  };
+}
+
+export default HomePage;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -12,7 +12,7 @@ function HomePage() {
 
   return (
     <Layout>
-      <Content page={undefined} />
+      <Content />
     </Layout>
   );
 }

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -61,22 +61,31 @@ function Login({ providers }: { providers: LoginProp }) {
 }
 
 export async function getServerSideProps(context: NextPageContext) {
-  const { req, res } = context;
-  const session = await getSession({ req });
+  try {
+    const { req, res } = context;
+    const session = await getSession({ req });
 
-  if (session && res && session.user) {
-    res.writeHead(302, {
-      Location: '/',
-    });
-    res.end();
-    return;
+    if (session && res && session.user) {
+      res.writeHead(302, {
+        Location: '/',
+      });
+      res.end();
+      return { props: {} };
+    }
+
+    return {
+      props: {
+        providers: await getProviders(),
+      },
+    };
+  } catch (error) {
+    return {
+      redirect: {
+        destination: '/login',
+        statusCode: 302,
+      },
+    };
   }
-
-  return {
-    props: {
-      providers: await getProviders(),
-    },
-  };
 }
 
 export default Login;

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -1,0 +1,82 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { NextPageContext } from 'next';
+import Head from 'next/head';
+import { getProviders, getSession, signIn } from 'next-auth/react';
+import { AiFillGithub } from 'react-icons/ai';
+import { FcGoogle } from 'react-icons/fc';
+import { RiKakaoTalkFill } from 'react-icons/ri';
+import { SiNaver } from 'react-icons/si';
+
+import { LoginProp } from '@/types';
+
+function Login({ providers }: { providers: LoginProp }) {
+  return (
+    <>
+      <Head>
+        <title>Meetion</title>
+      </Head>
+      <div className="flex h-screen flex-col justify-center bg-stone-50">
+        <header className="fix top-0 mx-5 h-[5%] text-xl font-bold">
+          Meetion
+        </header>
+        <div className="flex h-[95%] flex-col self-center">
+          <div className="flex h-[20%] items-center justify-center  align-middle text-4xl font-bold">
+            로그인
+          </div>
+          <div className="flex w-[350px] flex-col justify-center ">
+            <button
+              className="loginBtn"
+              onClick={() => signIn(providers!.google.id)}
+            >
+              <FcGoogle className="mr-2 h-5 w-5" />
+              Goolgle로 계속하기
+            </button>
+            <button
+              className="loginBtn bg-gray-800 text-white"
+              onClick={() => signIn(providers!.github.id)}
+            >
+              <AiFillGithub className="mr-2 h-5 w-5" />
+              Github으로 계속하기
+            </button>
+            <button
+              className="loginBtn bg-yellow-300"
+              onClick={() => signIn(providers!.kakao.id)}
+            >
+              <RiKakaoTalkFill className="mr-2 h-5 w-5" />
+              Kakao로 계속하기
+            </button>
+            <button
+              className="loginBtn bg-green-500 text-white"
+              onClick={() => signIn(providers!.naver.id)}
+            >
+              <SiNaver className="mr-2 h-5 w-5" />
+              Naver로 계속하기
+            </button>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+
+export async function getServerSideProps(context: NextPageContext) {
+  const { req, res } = context;
+  const session = await getSession({ req });
+
+  if (session && res && session.user) {
+    res.writeHead(302, {
+      Location: '/',
+    });
+    res.end();
+    return;
+  }
+
+  return {
+    props: {
+      providers: await getProviders(),
+    },
+  };
+}
+
+export default Login;

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -1,12 +1,8 @@
-/* eslint-disable react-hooks/exhaustive-deps */
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { NextPageContext } from 'next';
 import Head from 'next/head';
 import { getProviders, getSession, signIn } from 'next-auth/react';
-import { AiFillGithub } from 'react-icons/ai';
-import { FcGoogle } from 'react-icons/fc';
-import { RiKakaoTalkFill } from 'react-icons/ri';
-import { SiNaver } from 'react-icons/si';
+
+import { LoginProperties } from '@/lib/recoil';
 
 import { LoginProp } from '@/types';
 
@@ -25,34 +21,20 @@ function Login({ providers }: { providers: LoginProp }) {
             로그인
           </div>
           <div className="flex w-[350px] flex-col justify-center ">
-            <button
-              className="loginBtn"
-              onClick={() => signIn(providers!.google.id)}
-            >
-              <FcGoogle className="mr-2 h-5 w-5" />
-              Goolgle로 계속하기
-            </button>
-            <button
-              className="loginBtn bg-gray-800 text-white"
-              onClick={() => signIn(providers!.github.id)}
-            >
-              <AiFillGithub className="mr-2 h-5 w-5" />
-              Github으로 계속하기
-            </button>
-            <button
-              className="loginBtn bg-yellow-300"
-              onClick={() => signIn(providers!.kakao.id)}
-            >
-              <RiKakaoTalkFill className="mr-2 h-5 w-5" />
-              Kakao로 계속하기
-            </button>
-            <button
-              className="loginBtn bg-green-500 text-white"
-              onClick={() => signIn(providers!.naver.id)}
-            >
-              <SiNaver className="mr-2 h-5 w-5" />
-              Naver로 계속하기
-            </button>
+            {Object.values(providers).map((provider, i) => {
+              const Icon = LoginProperties[i].icon;
+
+              return (
+                <button
+                  key={provider.id}
+                  className={`loginBtn + ${LoginProperties[i].style}`}
+                  onClick={() => signIn(provider.id)}
+                >
+                  <Icon className="mr-2 h-5 w-5" />
+                  <span>{provider.name}로 계속하기</span>
+                </button>
+              );
+            })}
           </div>
         </div>
       </div>

--- a/src/pages/page/[pid].tsx
+++ b/src/pages/page/[pid].tsx
@@ -1,16 +1,20 @@
+import { NextPageContext } from 'next';
 import { useRouter } from 'next/router';
+import { getSession } from 'next-auth/react';
 import { useRecoilValue } from 'recoil';
 
-import { pageList } from '@/lib/recoil';
+import useHomePage from '@/lib/hooks/useHomePage';
+import { pageListState } from '@/lib/recoil';
 
 import Content from '@/components/layout/Content';
 import Layout from '@/components/layout/Layout';
 
 const Page = () => {
+  useHomePage();
   const router = useRouter();
 
   const { pid } = router.query;
-  const pages = useRecoilValue(pageList);
+  const pages = useRecoilValue(pageListState);
 
   let originalId: string;
 
@@ -19,13 +23,37 @@ const Page = () => {
     originalId = arr[arr.length - 1];
   }
 
-  const target = pages.find((page) => page._id === originalId);
+  const page = pages.find((page) => page._id === originalId);
 
   return (
     <Layout>
-      <Content page={target} />
+      <Content page={page} />
     </Layout>
   );
 };
+
+export async function getServerSideProps(context: NextPageContext) {
+  try {
+    const { req, res } = context;
+    const session = await getSession({ req });
+
+    if (!session && res) {
+      res.writeHead(302, {
+        Location: '/login',
+      });
+      res.end();
+      return { props: {} };
+    }
+
+    return { props: session };
+  } catch (error) {
+    return {
+      redirect: {
+        destination: '/login',
+        statusCode: 302,
+      },
+    };
+  }
+}
 
 export default Page;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -93,6 +93,10 @@
   .toolList {
     @apply flex items-center py-1 text-base font-normal text-gray-500 hover:bg-gray-200 dark:text-white dark:hover:bg-gray-700
   }
+
+  .loginBtn {
+    @apply flex h-10 items-center justify-center rounded border-[1px] border-gray-300 shadow hover:bg-slate-200 mb-3
+  }
 }
 
 @layer utilities {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -97,6 +97,10 @@
   .loginBtn {
     @apply flex h-10 items-center justify-center rounded border-[1px] border-gray-300 shadow hover:opacity-60 mb-3
   }
+
+  .selectedList {
+    @apply bg-gray-200
+  }
 }
 
 @layer utilities {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -95,7 +95,7 @@
   }
 
   .loginBtn {
-    @apply flex h-10 items-center justify-center rounded border-[1px] border-gray-300 shadow hover:bg-slate-200 mb-3
+    @apply flex h-10 items-center justify-center rounded border-[1px] border-gray-300 shadow hover:opacity-60 mb-3
   }
 }
 

--- a/src/types/commonType.ts
+++ b/src/types/commonType.ts
@@ -1,0 +1,3 @@
+export const queryKeys = {
+  pages: ['pages'] as const,
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,3 +10,34 @@ export interface UserType {
   image: string;
   name: string;
 }
+
+export interface LoginProp {
+  google: {
+    callbackUrl: string;
+    id: string;
+    name: string;
+    signinUrl: string;
+    type: string;
+  };
+  github: {
+    callbackUrl: string;
+    id: string;
+    name: string;
+    signinUrl: string;
+    type: string;
+  };
+  kakao: {
+    callbackUrl: string;
+    id: string;
+    name: string;
+    signinUrl: string;
+    type: string;
+  };
+  naver: {
+    callbackUrl: string;
+    id: string;
+    name: string;
+    signinUrl: string;
+    type: string;
+  };
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,3 +4,9 @@ export interface PageType {
   title: string;
   desc?: string;
 }
+
+export interface UserType {
+  email: string;
+  image: string;
+  name: string;
+}

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -1,0 +1,15 @@
+import { DefaultSession } from 'next-auth';
+
+declare module 'next-auth' {
+  /**
+   * Returned by `useSession`, `getSession` and received as a prop on the `SessionProvider` React Context
+   */
+  interface Session {
+    user: {
+      email: string;
+      name: string;
+      image: string;
+      address: string;
+    } & DefaultSession['user'];
+  }
+}


### PR DESCRIPTION
## ✅ What is this PR?

- 처음 계획은 SNS 로그인 시 session 유무에 따라 페이지를 다르게 보여주기 위해 CSR로 session이 있으면 router.push('/'), 없으면 router.push('/login')로 구현을 했었다. 하지만 초기 렌더링 시 session이 있다, 없다 하는 불안정한 상태가 되면서 session이 있는데도 불구하고 /login 페이지가 짧게 보이는 현상이 있었다. 그래서 getServerSideProps를 이용한 SSR로 session 유무에 따라 페이지 설정을 해놨더니 다른 문제없이 깔끔하게 페이지가 렌더링 되었다.
- 로그인 페이지 구현

## 📝 Changes

- [x] Login 페이지('/login') 생성 및 4개의 SNS 로그인 구현(Google, Github, Kakao, Naver)
- [x] 초기 렌더링 페이지(HomePage)에서 page 요청 및 로그인 된 유저 등록 api 요청을 하도록 리팩토링
- [x] 페이지 요청 시 로그인 한 유저 이메일을 params에 담아 요청하여 해당 이메일에 해당하는 페이지만 받아옴
- [x] user CRUD api 구현 및 userMutation 추가
- [x] Login button 리팩토링
- [x] 페이지 링크 시 Content 컴포넌트 title, desc 특정 상황에서 잘 안뜨는 에러 해결


## 📸 Screenshot
<img width="967" alt="image" src="https://user-images.githubusercontent.com/49411767/225691347-26965022-46f0-4437-814a-9c5909acf8f3.png">


## ⚠️ Note

- Kakao로 로그인 시 kakao developer에서 email, name, image를 제공하지 않아 에러가 발생함.