### PR TITLE
Fix: 배포사이트에서 발생한 next-auth 에러 수정  (23.04.03)

### DIFF
--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -31,5 +31,9 @@ export default NextAuth({
       clientSecret: process.env.NAVER_CLIENT_SECRET as string,
     }),
   ],
+  pages: {
+    signIn: '/auth/signin',
+    error: 'auth/error',
+  },
   secret: process.env.JWT_SECRET as string,
 });

--- a/src/pages/auth/signin.tsx
+++ b/src/pages/auth/signin.tsx
@@ -6,7 +6,7 @@ import { LoginProperties } from '@/lib/recoil';
 
 import { LoginProp } from '@/types';
 
-function Login({ providers }: { providers: LoginProp }) {
+function SignIn({ providers }: { providers: LoginProp }) {
   return (
     <>
       <Head>
@@ -63,11 +63,11 @@ export async function getServerSideProps(context: NextPageContext) {
   } catch (error) {
     return {
       redirect: {
-        destination: '/login',
+        destination: '/auth/signin',
         statusCode: 302,
       },
     };
   }
 }
 
-export default Login;
+export default SignIn;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -24,7 +24,7 @@ export async function getServerSideProps(context: NextPageContext) {
 
     if (!session && res) {
       res.writeHead(302, {
-        Location: '/login',
+        Location: '/auth/signin',
       });
       res.end();
       return { props: {} };
@@ -34,7 +34,7 @@ export async function getServerSideProps(context: NextPageContext) {
   } catch (error) {
     return {
       redirect: {
-        destination: '/login',
+        destination: '/auth/signin',
         statusCode: 302,
       },
     };


### PR DESCRIPTION
## ✅ What is this PR?

- netlify로 배포는 완료했지만 배포된 url에서 next-auth 에러로 페이지가 안뜨는 에러 해결을 위한 PR
- netlify settings에 .env variables 추가


## 📝 Changes

- [ ] `/login` path 를 `/auth/signin` 으로 수정
- [ ] nextauth에 pages 추가


## ⚠️ Note

- 각 SNS 별로 배포된 사이트 URL 추가 필요