### PR TITLE
🐛 Fix: _redirects 파일 추가로 SSL PROTOCOL 에러 해결해보기

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,2 @@
+/api/* http://ec2-43-207-223-70.ap-northeast-1.compute.amazonaws.com/api/:splat  200
+/* /index.html 200


### PR DESCRIPTION
## ✅ What is this PR?

- _redirects 파일 추가로 SSL PROTOCOL 에러 해결해보기


## 📝 Changes

- [ ] public 폴더에 _redirects 파일 추가
```
/api/* http://ec2-43-207-223-70.ap-northeast-1.compute.amazonaws.com/api/:splat  200
/* /index.html 200
```
## ⚠️ Note

- 안되면 원복하기