### PR TITLE
🐛 Fix: _redirects 파일 제거로 deploy Page Not Found 해결

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,2 +1,0 @@
-/api/* http://ec2-43-207-223-70.ap-northeast-1.compute.amazonaws.com/api/:splat  200
-/* /index.html 200


### PR DESCRIPTION
## ✅ What is this PR?

- _redirects 파일 제거로 deploy Page Not Found 해결


## 📝 Changes

- [ ] public 폴더에 _redirects 파일 삭제