### PR TITLE
🐛 Fix: netlify.toml에 redirects 추가로 net::ERR_SSL_PROTOCOL_ERROR 해결중

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,3 +4,14 @@
 
 [[plugins]]
   package = "@netlify/plugin-nextjs"
+
+[[redirects]]
+  from = "/api/*"
+  to = "http://ec2-43-207-223-70.ap-northeast-1.compute.amazonaws.com/api/:splat"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200


### PR DESCRIPTION
## ✅ What is this PR?

- netlify.toml에 redirects 추가로 net::ERR_SSL_PROTOCOL_ERROR 해결중


## 📝 Changes

- [ ]  netlify.toml에 redirects 추가
```

[[redirects]]
  from = "/api/*"
  to = "http://ec2-43-207-223-70.ap-northeast-1.compute.amazonaws.com/api/:splat"
  status = 200
  force = true

[[redirects]]
  from = "/*"
  to = "/index.html"
  status = 200
```

## ⚠️ Note

- 배포된 사이트 실행 안될 시 원복